### PR TITLE
Add support for checking processes by pattern matching

### DIFF
--- a/manifests/checkpid.pp
+++ b/manifests/checkpid.pp
@@ -8,7 +8,7 @@
 #
 define monit::checkpid (
   $process      = '',
-  $template     = 'monit/checkprocess.erb',
+  $template     = 'monit/checkpid.erb',
   $pidfile      = '',
   $startprogram = '',
   $stopprogram  = '',
@@ -26,9 +26,7 @@ define monit::checkpid (
     default => $process,
   }
 
-  $check_type = 'pidfile'
-
-  $check_argument = $pidfile ? {
+  $real_pidfile = $pidfile ? {
     ''      => "/var/run/${process}.pid",
     default => $pidfile,
   }

--- a/manifests/checkprocessmatch.pp
+++ b/manifests/checkprocessmatch.pp
@@ -9,7 +9,7 @@
 #
 define monit::checkprocessmatch (
   $process      = '',
-  $template     = 'monit/checkprocess.erb',
+  $template     = 'monit/checkprocessmatch.erb',
   $pattern      = '',
   $startprogram = '',
   $stopprogram  = '',
@@ -27,9 +27,7 @@ define monit::checkprocessmatch (
     default => $process,
   }
 
-  $check_type = 'matching'
-
-  $check_argument = $pattern ? {
+  $real_pattern = $pattern ? {
     ''      => $real_process,
     default => $pattern,
   }

--- a/templates/checkpid.erb
+++ b/templates/checkpid.erb
@@ -1,0 +1,6 @@
+## This file is managed by Puppet
+
+check process <%= @real_process %> with pidfile "<%= @real_pidfile %>"
+    start program  "<%= @real_startprogram %>"
+    stop program  "<%= @real_stopprogram %>"
+    if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>

--- a/templates/checkprocessmatch.erb
+++ b/templates/checkprocessmatch.erb
@@ -1,6 +1,6 @@
 ## This file is managed by Puppet
 
-check process <%= @real_process %> <%= @check_type %> "<%= @check_argument %>"
+check process <%= @real_process %> matching "<%= @real_pattern %>"
     start program  "<%= @real_startprogram %>"
     stop program  "<%= @real_stopprogram %>"
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>


### PR DESCRIPTION
This involved adding a new class, `monit::checkprocessmatch`, which is very similar to `monit::checkpid`. It uses the same template as `monit::checkpid`, which I renamed for clarity.

Relevant docs: http://mmonit.com/monit/documentation/monit.html#check_process_unique_name_pidfile_path_matching_regex
