### PR TITLE
Allow specifying additional tests for service config as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           absent => true
         }
 
+* Monitor a service (SSH in this example) by its pid file
+
+        class { 'monit::checkpid':
+          process => 'sshd',
+          pidfile => '/var/run/sshd.pid'
+        }
 
 ## USAGE - Overrides and Customizations
 * Use custom sources for main config file
@@ -67,6 +73,13 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           my_class => 'example42::my_monit',
         }
 
+* Include additional tests for a service config file
+
+        class { 'monit::checkpid':
+          process          => 'sshd',
+          pidfile          => '/var/run/sshd.pid',
+          additional_tests => 'if failed host 192.168.1.100 port 22 then alert'
+        }
 
 ## USAGE - Example42 extensions management 
 * Activate puppi (recommended, but disabled by default)

--- a/manifests/checkpid.pp
+++ b/manifests/checkpid.pp
@@ -7,15 +7,16 @@
 # monit::checkpid  { "name": }
 #
 define monit::checkpid (
-  $process      = '',
-  $template     = 'monit/checkpid.erb',
-  $pidfile      = '',
-  $startprogram = '',
-  $stopprogram  = '',
-  $restarts     = '5',
-  $cycles       = '5',
-  $failaction   = 'timeout',
-  $enable       = true ) {
+  $process          = '',
+  $template         = 'monit/checkpid.erb',
+  $pidfile          = '',
+  $startprogram     = '',
+  $stopprogram      = '',
+  $restarts         = '5',
+  $cycles           = '5',
+  $failaction       = 'timeout',
+  $additional_tests = '',
+  $enable           = true ) {
 
   $ensure=bool2ensure($enable)
 

--- a/manifests/checkprocessmatch.pp
+++ b/manifests/checkprocessmatch.pp
@@ -8,15 +8,16 @@
 # monit::checkprocessmatch { "name": }
 #
 define monit::checkprocessmatch (
-  $process      = '',
-  $template     = 'monit/checkprocessmatch.erb',
-  $pattern      = '',
-  $startprogram = '',
-  $stopprogram  = '',
-  $restarts     = '5',
-  $cycles       = '5',
-  $failaction   = 'timeout',
-  $enable       = true ) {
+  $process          = '',
+  $template         = 'monit/checkprocessmatch.erb',
+  $pattern          = '',
+  $startprogram     = '',
+  $stopprogram      = '',
+  $restarts         = '5',
+  $cycles           = '5',
+  $failaction       = 'timeout',
+  $additional_tests = '',
+  $enable           = true ) {
 
   $ensure=bool2ensure($enable)
 

--- a/manifests/checkurl.pp
+++ b/manifests/checkurl.pp
@@ -11,12 +11,13 @@
 # }
 #
 define monit::checkurl (
-  $fqdn         = '',
-  $template     = 'monit/checkurl.erb',
-  $url          = '',
-  $content      = '',
-  $failaction   = 'alert',
-  $enable       = true ) {
+  $fqdn             = '',
+  $template         = 'monit/checkurl.erb',
+  $url              = '',
+  $content          = '',
+  $failaction       = 'alert',
+  $additional_tests = '',
+  $enable           = true ) {
 
   $ensure=bool2ensure($enable)
 

--- a/templates/checkpid.erb
+++ b/templates/checkpid.erb
@@ -4,3 +4,4 @@ check process <%= @real_process %> with pidfile "<%= @real_pidfile %>"
     start program  "<%= @real_startprogram %>"
     stop program  "<%= @real_stopprogram %>"
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>
+    <%= @additional_tests %>

--- a/templates/checkprocessmatch.erb
+++ b/templates/checkprocessmatch.erb
@@ -4,3 +4,4 @@ check process <%= @real_process %> matching "<%= @real_pattern %>"
     start program  "<%= @real_startprogram %>"
     stop program  "<%= @real_stopprogram %>"
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>
+    <%= @additional_tests %>

--- a/templates/checkurl.erb
+++ b/templates/checkurl.erb
@@ -3,3 +3,4 @@
 check host <%= @name %> with address <%= @real_fqdn %>
     if failed url <%= @real_url %> <% if (@content != '') %> and content == '<%= @content %>' <% end %>
     then <%= @failaction %>
+    <%= @additional_tests %>


### PR DESCRIPTION
This is kind of a hack since it takes a plain string and includes it without proper validation, but the monit config format is too complex to represent as a hash and can't be easily validated. Making a resource with multiple templates a-la https://github.com/netmanagers/puppet-nginx/blob/master/manifests/resource/vhost.pp would be possible, but that seems a little excessive to me. 

Reference for monit config: http://mmonit.com/monit/documentation/monit.html#service_tests
