### PR TITLE
Add processuid and processgid to the define, after PR #12 if not defined...

### DIFF
--- a/manifests/checkfile.pp
+++ b/manifests/checkfile.pp
@@ -1,0 +1,68 @@
+# Define: monit::checkfile
+#
+# Basic file checking define that works by pattern matching
+#
+# Usage:
+# With standard template:
+# monit::checkfile { "name": 
+#  pattern =>  'string to search'}
+#
+define monit::checkfile (
+  $process      = '',
+  $processuid   = '',
+  $processgid   = '',
+  $file         = '',
+  $template     = 'monit/checkfile.erb',
+  $pattern      = '',
+  $startprogram = '',
+  $stopprogram  = '',
+  $restarts     = '5',
+  $cycles       = '5',
+  $failaction   = 'timeout',
+  $enable       = true ) {
+
+  $ensure=bool2ensure($enable)
+
+  include monit
+
+  $real_file = $file ? {
+    ''      => $name,
+    default => $file,
+  }
+
+  $real_pattern = $pattern
+  $real_process = $process
+
+  $real_startprogram = $startprogram ? {
+    ''      => "/etc/init.d/${process} start",
+    default => $startprogram,
+  }
+
+  $real_stopprogram = $stopprogram ? {
+    ''      => "/etc/init.d/${process} stop",
+    default => $stopprogram,
+  }
+
+  $real_processuid = $processuid ? {
+    ''      => $monit::process_user,
+    default => $processuid,
+  }
+
+  $real_processgid = $processgid ? {
+    ''      => $monit::process_group,
+    default => $processgid,
+  }
+
+  file { "MonitCheckFile_${name}":
+    ensure  => $ensure,
+    path    => "${monit::plugins_dir}/${name}",
+    mode    => $monit::config_file_mode,
+    owner   => $monit::config_file_owner,
+    group   => $monit::config_file_group,
+    require => Package[$monit::package],
+    notify  => $monit::manage_service_autorestart,
+    content => template($template),
+    replace => $monit::manage_file_replace,
+  }
+
+}

--- a/manifests/checkpid.pp
+++ b/manifests/checkpid.pp
@@ -8,6 +8,8 @@
 #
 define monit::checkpid (
   $process      = '',
+  $processuid   = '',
+  $processgid   = '',
   $template     = 'monit/checkpid.erb',
   $pidfile      = '',
   $startprogram = '',

--- a/manifests/checkprocessmatch.pp
+++ b/manifests/checkprocessmatch.pp
@@ -9,6 +9,8 @@
 #
 define monit::checkprocessmatch (
   $process      = '',
+  $processuid   = '',
+  $processgid   = '',
   $template     = 'monit/checkprocessmatch.erb',
   $pattern      = '',
   $startprogram = '',

--- a/templates/checkfile.erb
+++ b/templates/checkfile.erb
@@ -1,0 +1,8 @@
+## This file is managed by Puppet
+
+check file <%= @real_process %>_file with path <%= @real_file %>
+    start program  "<%= @real_startprogram %>"
+    stop program  "<%= @real_stopprogram %>"
+    as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    if match "<%= @real_pattern %>" then restart
+    if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>


### PR DESCRIPTION
... these 2 values are put as monit. It's useful to specify for each define which user:group should be used to run that process