### PR TITLE
fixed missing uid/gid settings after start program

### DIFF
--- a/templates/checkfile.erb
+++ b/templates/checkfile.erb
@@ -1,8 +1,7 @@
 ## This file is managed by Puppet
 
 check file <%= @real_process %>_file with path <%= @real_file %>
-    start program  "<%= @real_startprogram %>"
-    stop program  "<%= @real_stopprogram %>"
-    as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    start program  "<%= @real_startprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    stop program  "<%= @real_stopprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
     if match "<%= @real_pattern %>" then restart
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>

--- a/templates/checkpid.erb
+++ b/templates/checkpid.erb
@@ -1,7 +1,6 @@
 ## This file is managed by Puppet
 
 check process <%= @real_process %> with pidfile "<%= @real_pidfile %>"
-    start program  "<%= @real_startprogram %>"
-    stop program  "<%= @real_stopprogram %>"
-    as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    start program  "<%= @real_startprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    stop program  "<%= @real_stopprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>

--- a/templates/checkprocessmatch.erb
+++ b/templates/checkprocessmatch.erb
@@ -1,7 +1,6 @@
 ## This file is managed by Puppet
 
 check process <%= @real_process %> matching "<%= @real_pattern %>"
-    start program  "<%= @real_startprogram %>"
-    stop program  "<%= @real_stopprogram %>"
-    as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    start program  "<%= @real_startprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
+    stop program  "<%= @real_stopprogram %>" as uid <%= @real_processuid %> and gid <%= @real_processgid %>
     if <%= @restarts %> restarts within <%= @cycles %> cycles then <%= @failaction %>


### PR DESCRIPTION
We noticed that our processes were started as root, ignoring uid/gid settings on the last line of the template. After checking the monit docs, it appears that 'as uid and gid' is needed after both start and stop lines, or on the same line as found in this PR.  Thank you