### PR TITLE
Fix use of empty string my_class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -509,7 +509,7 @@ class monit (
 
 
   ### Include custom class if $my_class is set
-  if $monit::my_class and $openssh::my_class != '' {
+  if $monit::my_class and $monit::my_class != '' {
     include $monit::my_class
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -509,7 +509,7 @@ class monit (
 
 
   ### Include custom class if $my_class is set
-  if $monit::my_class {
+  if $monit::my_class and $openssh::my_class != '' {
     include $monit::my_class
   }
 


### PR DESCRIPTION
`Evaluation Error: Error while evaluating a Function Call, Cannot use empty string as a class name`

Fixed it according to your other modules.

